### PR TITLE
Proposal: Introduce UI Errors on ViewModel and more dumb Views.

### DIFF
--- a/Packages/Feature/Sources/Feature/CountryDetails/Components/CountryNotFoundErrorView.swift
+++ b/Packages/Feature/Sources/Feature/CountryDetails/Components/CountryNotFoundErrorView.swift
@@ -14,39 +14,42 @@ import UIComponents
 
 /// Content is a component of a page. Content accepts bindings or simple primitive types.
 public struct CountryNotFoundErrorView: View {
-    private let viewModelState: CountryDetailsViewModel.State
+    private let uiError: CountryDetailsUIError
 
-    public init(viewModelState: CountryDetailsViewModel.State) {
-        self.viewModelState = viewModelState
+    public init(error: CountryDetailsUIError) {
+        self.uiError = error
     }
 
     public var body: some View {
-        switch viewModelState {
-        case .error(let error):
-            if case .countryNotFound = error {
-                ZStack {
-                    Color.red
-                        .ignoresSafeArea()
+        ZStack {
+            Color.red
+                .ignoresSafeArea()
 
-                    VStack {
-                        L10n.Errors.countryNotFoundErrorTitle.text
-                            .bold()
-                            .foregroundColor(.white)
-                        L10n.Errors.countryNotFoundErrorMessage.text
-                            .foregroundColor(.white)
-                    }
-                }.frame(maxWidth: 200, maxHeight: 200)
-            } else {
-                Spacer().hidden()
+            VStack {
+                uiError.title
+                    .text
+                    .bold()
+                    .foregroundColor(.white)
+                uiError.message
+                    .text
+                    .foregroundColor(.white)
             }
-        default:
-            EmptyView().hidden()
-        }
+        }.frame(maxWidth: 200, maxHeight: 200)
     }
 }
 
 struct CountryNotFoundErrorView_Previews: PreviewProvider {
     static var previews: some View {
-        CountryNotFoundErrorView(viewModelState: .error(error: .countryNotFound))
+        CountryNotFoundErrorView(error: .notFound)
+    }
+}
+
+extension CountryDetailsUIError {
+    var title: LocalizedString {
+        L10n.Errors.countryNotFoundErrorTitle
+    }
+    
+    var message: LocalizedString {
+        L10n.Errors.countryNotFoundErrorMessage
     }
 }

--- a/Packages/Feature/Sources/Feature/CountryDetails/Pages/CountryDetailsPage.swift
+++ b/Packages/Feature/Sources/Feature/CountryDetails/Pages/CountryDetailsPage.swift
@@ -23,27 +23,31 @@ public struct CountryDetailsPage: View {
 
     public var body: some View {
         ZStack {
-            ProgressIndicator(isLoading: detailsUiState.isLoading)
-            CountryNotFoundErrorView(viewModelState: detailsUiState)
-            CountryDetailsContent(countryName: extractCountryName(from: detailsUiState),
-                                  detailsText: extractCountryDetails(from: detailsUiState))
+            switch detailsUiState {
+            case .loading: renderLoading()
+            case .loaded(let details): renderDetails(details: details)
+            case .error(let error) where error == .other: renderEmptyView()
+            case .error(let error): renderError(error: error)
+            default: EmptyView().hidden()
+            }
         }
     }
-
-    private func extractCountryName(from detailsUiState: CountryDetailsViewModel.State) -> String {
-        if case .loaded(let details) = detailsUiState {
-            return details.country.countryName ?? ""
-        } else {
-            return ""
-        }
+    
+    private func renderLoading() -> some View {
+        ProgressIndicator(isLoading: detailsUiState.isLoading)
     }
-
-    private func extractCountryDetails(from detailsUiState: CountryDetailsViewModel.State) -> String {
-        if case .loaded(let details) = detailsUiState {
-            return details.detailsText ?? ""
-        } else {
-            return ""
-        }
+    
+    private func renderEmptyView() -> some View {
+        EmptyView().hidden()
+    }
+    
+    private func renderDetails(details: CountryDetails) -> some View {
+        CountryDetailsContent(countryName: details.country.countryName ?? "",
+                              detailsText: details.detailsText ?? "")
+    }
+    
+    private func renderError(error: CountryDetailsUIError) -> some View {
+        CountryNotFoundErrorView(error: error)
     }
 }
 

--- a/Packages/ViewModels/Sources/ViewModels/CountryDetailsViewModel.swift
+++ b/Packages/ViewModels/Sources/ViewModels/CountryDetailsViewModel.swift
@@ -15,7 +15,7 @@ public class CountryDetailsViewModel: ObservableObject {
         case initial
         case loading
         case loaded(details: CountryDetails)
-        case error(error: CountryDetailsError)
+        case error(error: CountryDetailsUIError)
 
         public var isLoading: Bool {
             switch self {
@@ -51,7 +51,7 @@ public class CountryDetailsViewModel: ObservableObject {
             }).sink(receiveCompletion: { [weak self] completion in
                 switch completion {
                 case .failure(let error):
-                    self?.state = .error(error: error)
+                    self?.state = .error(error: error.uiError())
                 case .finished:
                     break
                 }
@@ -59,4 +59,17 @@ public class CountryDetailsViewModel: ObservableObject {
             .store(in: &cancellables)
     }
 
+}
+
+/// Domain Errors mapping to UI Error
+extension CountryDetailsError {
+    func uiError() -> CountryDetailsUIError {
+        switch self {
+        case .countryNotFound:
+            return .notFound
+        case .other:
+            return .other
+        }
+    }
+    
 }

--- a/Packages/ViewModels/Sources/ViewModels/Error/CountryDetailsUIError.swift
+++ b/Packages/ViewModels/Sources/ViewModels/Error/CountryDetailsUIError.swift
@@ -1,0 +1,13 @@
+//
+//  File.swift
+//  
+//
+//  Created by Lucas Cavalcante on 11/9/22.
+//
+
+import Foundation
+
+public enum CountryDetailsUIError: Equatable {
+    case notFound
+    case other
+}


### PR DESCRIPTION
**Summary**

- View does not need to know about `domainErrors`, instead they just show an `title | message` error
- Error view now just show data, it does not have a control flow onto .State anymore 
- ViewModel to expose UiError